### PR TITLE
docs: Change demo database password

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ module "fleet-service" {
   aws_region = "us-east-1"
   aws_zones  = ["us-east-1a", "us-east-1b"]
 
-  db_password = "p@ssw0rd"
+  db_password = "pa$$w0rd"
   db_subnet_group_name = "${aws_subnet.db_subnet_group_name.name}"
 
   elasticache_subnet_group_name = "${aws_subnet.elasticache_subnet_group_name.name}"


### PR DESCRIPTION
Fun fact AWS won't let you create a database with a default password of `p@ssw0rd`.

```bash
* aws_db_instance.fleet_db: Error creating DB Instance: InvalidParameterValue: The parameter MasterUserPassword is not a valid password. Only printable ASCII characters besides '/', '@', '"', ' ' may be used.
	status code: 400, request id: XXX-XXX-XXX-XX-XXXX
```

For production, everyone should be changing this password but for demo reasons, people should be able to copy/paste with the least amount of changes to see if they can get it to work.